### PR TITLE
Fix invalid group failure bug and baseDn

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -791,8 +791,14 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
 
         final Set<LdapName> result = new HashSet<>(20);
         final HashMultimap<LdapName, Map.Entry<String, Settings>> resultRoleSearchBaseKeys = HashMultimap.create();
-
-        final LdapEntry e0 = LdapHelper.lookup(ldapConnection, roleDn.toString());
+        
+        LdapEntry e0 = null;
+        try {
+            e0 = LdapHelper.lookup(ldapConnection, roleDn.toString());
+        } catch (LdapException e) {
+            log.debug("Error found while going over nested groups ", e);
+            return result;
+        }
 
         if (e0.getAttribute(userRoleName) != null) {
             final Collection<String> userRoles = e0.getAttribute(userRoleName).getStringValues();


### PR DESCRIPTION
Fixed two bugs:
* dn turned into baseDn - currently wasn't happening - the lookup function received the original dn as baseDn.
* When an error occurred while going over nested groups in one of the groups - due to LDAP wrong or missing results none of the roles were returned. Caught the exception 