### PR TITLE
Allow KID of JWK's to contain forward slashes. 

### DIFF
--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -65,6 +65,24 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 	}
 
 	@Test
+	public void testEscapeKid() {
+		Settings settings = Settings.builder().put("openid_connect_url", mockIdpServer.getDiscoverUri()).build();
+
+		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
+
+		System.out.println("Entering Escape Kid ");
+
+		AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(
+				ImmutableMap.of("Authorization",  "Bearer " + TestJwts.MC_COY_SIGNED_OCT_1_INVALID_KID), new HashMap<String, String>()), null);
+
+		Assert.assertNotNull(creds);
+		Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
+		Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
+		Assert.assertEquals(0, creds.getBackendRoles().size());
+		Assert.assertEquals(3, creds.getAttributes().size());
+	}
+
+	@Test
 	public void bearerTest() {
 		Settings settings = Settings.builder().put("openid_connect_url", mockIdpServer.getDiscoverUri()).build();
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -70,8 +70,6 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
 		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
 
-		System.out.println("Entering Escape Kid ");
-
 		AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(
 				ImmutableMap.of("Authorization",  "Bearer " + TestJwts.MC_COY_SIGNED_OCT_1_INVALID_KID), new HashMap<String, String>()), null);
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwk.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwk.java
@@ -33,8 +33,10 @@ class TestJwk {
 	static final JsonWebKey OCT_1 = createOct("kid_a", "HS256", OCT_1_K);
 	static final JsonWebKey OCT_2 = createOct("kid_b", "HS256", OCT_2_K);
 	static final JsonWebKey OCT_3 = createOct("kid_c", "HS256", OCT_3_K);
+	static final JsonWebKey ESCAPED_SLASH_KID_OCT_1 = createOct("kid\\/_a", "HS256", OCT_1_K);
+	static final JsonWebKey FORWARD_SLASH_KID_OCT_1 = createOct("kid/_a", "HS256", OCT_1_K);
 
-	static final JsonWebKeys OCT_1_2_3 = createJwks(OCT_1, OCT_2, OCT_3);
+	static final JsonWebKeys OCT_1_2_3 = createJwks(OCT_1, OCT_2, OCT_3, FORWARD_SLASH_KID_OCT_1,ESCAPED_SLASH_KID_OCT_1);
 
 	static final String RSA_1_D = "On8XGMmdM5Fm5hvuhQk-qAkIP2CoK5QMx0OH5m_WDzKXZv8lZ2eg89I4ehBiOKGdw1h_mjmWwTah-evpXV-BF5QpejPQqxkXS-8s5r2AvietQq32jl-gwIwZWTvfzjpT9On0YJZ4q01tMDj3r-YOLUW2xrz3za9tl6pPU_5kP63C-hoj1ybTwcC7ujbCPwhY6yAopMA1v10uVmCxsjsNikEjB6YePgHixez51wO3Z8mXNwefWukFWYJ5T7t4kHMSf5P_8FJZ14u5yvYZnngE_tJCyHFdIDb6UWsrgxomtlQU-SdZYK_NY6gw6mCkjjlqOoYqlsrRJ16kJ81Ds269oQ";
 	static final String RSA_1_N = "hMSoV74FRtoaU7xpp0llsXbHE4oUseKoSNga-C_YIXuoGc3pajHh1WtJppZQNYM1Xy07nHchLJAdgqL2_q_Lk8cFHmmL1KTjwPflK9zZ9C0-8QTOrrqU9vkp3gT00jWWJ0HJbUvXIGxPGPnxoJoI--ToE0EWsYEWqWyx1TqYol--oUUPlY5r7vXRKIn5UZNz6VGkW8nI4fXaqDUpXH9uVM9A-nJX2B0Xjwu3VOn2zrgkCZeGTHjNgfLISOTFe9m8lHWLKcuxOWPuCZyCN0C6ZdWB1YP2NhxYFQwQfGV8yfnTImgL-DuV4WPSRVj7W_GJr213-oXBrBR0CnQEPbi_3w";
@@ -60,7 +62,7 @@ class TestJwk {
 	static final JsonWebKeys RSA_1_2_PUBLIC = createJwks(RSA_1_PUBLIC, RSA_2_PUBLIC);
 
 	static class Jwks {
-		static final JsonWebKeys ALL = createJwks(OCT_1, OCT_2, OCT_3, RSA_1_PUBLIC, RSA_2_PUBLIC);
+		static final JsonWebKeys ALL = createJwks(OCT_1, OCT_2, OCT_3, FORWARD_SLASH_KID_OCT_1, RSA_1_PUBLIC, RSA_2_PUBLIC);
 		static final JsonWebKeys RSA_1 = createJwks(RSA_1_PUBLIC);
 		static final JsonWebKeys RSA_2 = createJwks(RSA_2_PUBLIC);
 	}

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
@@ -44,6 +44,8 @@ class TestJwts {
 
 	static final String MC_COY_SIGNED_OCT_1 = createSigned(MC_COY, TestJwk.OCT_1);
 
+	static final String MC_COY_SIGNED_OCT_1_INVALID_KID = createSigned(MC_COY, TestJwk.FORWARD_SLASH_KID_OCT_1);
+
 	static final String MC_COY_SIGNED_RSA_1 = createSigned(MC_COY, TestJwk.RSA_1);
 
 	static final String MC_COY_SIGNED_RSA_X = createSigned(MC_COY, TestJwk.RSA_X);


### PR DESCRIPTION
https://github.com/opendistro-for-elasticsearch/security/issues/27

Seems like the escaped characters are making it's way into JWT verifier. The code strips those characters and allows them to go through. AWS cognito provides JWK's that could have a kid with a '/' .. It is currently getting '\/' escaped.  