### PR TITLE
Update the version string of jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <log4j.version>2.11.1</log4j.version>
     <jjwt.version>0.10.5</jjwt.version>
     <ldaptive.version>1.2.3</ldaptive.version>
-    <jackson-databind.version>2.8.11.2</jackson-databind.version>
+    <jackson-databind.version>2.9.9</jackson-databind.version>
     <http.commons.version>4.5.3</http.commons.version>
     <cxf.version>3.2.2</cxf.version>
     <guava.version>25.1-jre</guava.version>


### PR DESCRIPTION
Updated the version of jackson-databind to avoid potential security vulnerability. (see [here](https://github.com/opendistro-for-elasticsearch/security-advanced-modules/network/alert/pom.xml/com.fasterxml.jackson.core:jackson-databind/open))

Test:

mvn package
[INFO] Results:
[WARNING] Tests run: 541, Failures: 0, Errors: 0, Skipped: 5
