### PR TITLE
Changes to support Protected index

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityFlsDlsIndexSearcherWrapper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityFlsDlsIndexSearcherWrapper.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.LongSupplier;
 
+import com.amazon.opendistroforelasticsearch.security.privileges.PrivilegesEvaluator;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -57,8 +58,8 @@ public class OpenDistroSecurityFlsDlsIndexSearcherWrapper extends OpenDistroSecu
 
     public OpenDistroSecurityFlsDlsIndexSearcherWrapper(final IndexService indexService, final Settings settings,
             final AdminDNs adminDNs, final ClusterService clusterService, final AuditLog auditlog,
-            final ComplianceIndexingOperationListener ciol, final ComplianceConfig complianceConfig) {
-        super(indexService, settings, adminDNs);
+            final ComplianceIndexingOperationListener ciol, final ComplianceConfig complianceConfig, final PrivilegesEvaluator evaluator) {
+        super(indexService, settings, adminDNs, evaluator);
         ciol.setIs(indexService);
         this.clusterService = clusterService;
         this.indexService = indexService;


### PR DESCRIPTION
# Information
This is needed to support the protected index PR.
It brings in the PrivilegesEvaluator into OpenDistroSecurityFlsDlsIndexSearcherWrapper. This allows us to use roles to exclude and include search results pertaining to certain indices.

# Test results
```
[INFO] Results:
[INFO] 
[WARNING] Tests run: 556, Failures: 0, Errors: 0, Skipped: 5
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11:53 min
[INFO] Finished at: 2019-09-04T18:26:18Z
[INFO] ------------------------------------------------------------------------
```

# Dependency
This change depends on the security module code change found [here](https://github.com/opendistro-for-elasticsearch/security/pull/126).

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._