### PR TITLE
Bumping subversion 0.10.0.2

### DIFF
--- a/opendistro-elasticsearch-security.release-notes
+++ b/opendistro-elasticsearch-security.release-notes
@@ -1,0 +1,37 @@
+## 2019-09-06, Version 0.10.0.2
+
+- Add the ability to block indices and index patterns to certain roles, adding another level of protection for these indices
+
+## 2019-08-21, Version 0.10.0.1
+
+- Fix API path naming issue
+
+## 2019-07-23, Version 0.10.0.0
+
+-Support For Elasticsearch 6.8
+
+## 2019-07-15, Version 0.9.0.1
+
+- Add PUT and PATCH method for securityconfig
+    /_opendistro/_security/api/securityconfig
+
+## 2019-04-23, Version 0.9.0.0
+
+- Support For Elasticsearch 6.7
+- Handle attributes when impersonating user
+
+## 2019-04-04, Version 0.8.0.0
+
+- Support For  Elasticsearch 6.6
+
+## 2019-03-19, Version 0.7.0.1
+ 
+- Fixed git repo URLs in pom.xml
+- Handle overridden Transport channels.
+- Fixed "opendistro_security.advanced_modules_enabled" configuration parameter
+- Fixed sample configuration and UTs
+
+
+## 2019-03-12, Version 0.7.0.0
+
+- Initial launch of security for opendistro-for-elasticsearch

--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,11 @@
   <parent>
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
     <artifactId>opendistro_security_parent</artifactId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.2</version>
   </parent>
 
   <artifactId>opendistro_security_advanced_modules</artifactId>
-  <version>0.10.0.1</version>
+  <version>0.10.0.2</version>
   <packaging>jar</packaging>
 
   <name>Open Distro For Elasticsearch Advanced Modules</name>
@@ -33,7 +33,7 @@
   <inceptionYear>2016</inceptionYear>
 
   <properties>
-    <security.version>0.10.0.1</security.version>
+    <security.version>0.10.0.2</security.version>
     <elasticsearch.version>6.8.1</elasticsearch.version>
 
     <!-- deps -->
@@ -54,7 +54,7 @@
     <url>https://github.com/opendistro-for-elasticsearch/security-advanced-modules</url>
     <connection>scm:git:git@github.com:opendistro-for-elasticsearch/security-advanced-modules.git</connection>
     <developerConnection>scm:git:git@github.com:opendistro-for-elasticsearch/security-advanced-modules.git</developerConnection>
-    <tag>v0.10.0.1</tag>
+    <tag>v0.10.0.2</tag>
   </scm>
 
   <issueManagement>


### PR DESCRIPTION
Update subversion tags.

[INFO] Results:
[INFO]
[WARNING] Tests run: 551, Failures: 0, Errors: 0, Skipped: 5
[INFO]
[INFO]
[INFO] --- maven-jar-plugin:3.1.0:jar (default-jar) @ opendistro_security_advanced_modules ---
[INFO] Building jar: /Opendistro/security-advanced-modules/target/opendistro_security_advanced_modules-0.10.0.2.jar
[INFO]
[INFO] --- git-commit-id-plugin:2.2.3:validateRevision (validate-the-git-infos) @ opendistro_security_advanced_modules ---
[INFO]
[INFO] --- maven-jar-plugin:3.1.0:test-jar (default) @ opendistro_security_advanced_modules ---
[INFO] Building jar: /Opendistro/security-advanced-modules/target/opendistro_security_advanced_modules-0.10.0.2-tests.jar
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ opendistro_security_advanced_modules ---
[INFO] Installing /Opendistro/security-advanced-modules/target/opendistro_security_advanced_modules-0.10.0.2.jar to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security_advanced_modules/0.10.0.2/opendistro_security_advanced_modules-0.10.0.2.jar
[INFO] Installing /Opendistro/security-advanced-modules/pom.xml to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security_advanced_modules/0.10.0.2/opendistro_security_advanced_modules-0.10.0.2.pom
[INFO] Installing /Opendistro/security-advanced-modules/target/opendistro_security_advanced_modules-0.10.0.2-tests.jar to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security_advanced_modules/0.10.0.2/opendistro_security_advanced_modules-0.10.0.2-tests.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------