### PR TITLE
Bumping subversion 0.9.0.4

### DIFF
--- a/opendistro-elasticsearch-security.release-notes
+++ b/opendistro-elasticsearch-security.release-notes
@@ -1,4 +1,8 @@
-## 2019-09-06, Version 0.9.0.3 (Current)
+## 2019-09-11, Version 0.9.0.4 (Current)
+
+- Fix protected index kibana in security package
+
+## 2019-09-06, Version 0.9.0.3
 
 - Add the ability to block indices and index patterns to certain roles, adding another level of protection for these indices
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,11 @@
   <parent>
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
     <artifactId>opendistro_security_parent</artifactId>
-    <version>0.9.0.3</version>
+    <version>0.9.0.4</version>
   </parent>
 
   <artifactId>opendistro_security_advanced_modules</artifactId>
-  <version>0.9.0.3</version>
+  <version>0.9.0.4</version>
   <packaging>jar</packaging>
 
   <name>Open Distro For Elasticsearch Advanced Modules</name>
@@ -33,7 +33,7 @@
   <inceptionYear>2016</inceptionYear>
 
   <properties>
-    <security.version>0.9.0.3</security.version>
+    <security.version>0.9.0.4</security.version>
     <elasticsearch.version>6.7.1</elasticsearch.version>
 
     <!-- deps -->
@@ -54,7 +54,7 @@
     <url>https://github.com/opendistro-for-elasticsearch/security-advanced-modules</url>
     <connection>scm:git:git@github.com:opendistro-for-elasticsearch/security-advanced-modules.git</connection>
     <developerConnection>scm:git:git@github.com:opendistro-for-elasticsearch/security-advanced-modules.git</developerConnection>
-    <tag>v0.9.0.3</tag>
+    <tag>v0.9.0.4</tag>
   </scm>
 
   <issueManagement>


### PR DESCRIPTION
Update pom file and release notes.

[INFO] Results:
[INFO]
[WARNING] Tests run: 551, Failures: 0, Errors: 0, Skipped: 5
[INFO]
[INFO]
[INFO] --- maven-jar-plugin:3.1.0:jar (default-jar) @ opendistro_security_advanced_modules ---
[INFO] Building jar: /Opendistro/security-advanced-modules/target/opendistro_security_advanced_modules-0.9.0.4.jar
[INFO]
[INFO] --- git-commit-id-plugin:2.2.3:validateRevision (validate-the-git-infos) @ opendistro_security_advanced_modules ---
[INFO]
[INFO] --- maven-jar-plugin:3.1.0:test-jar (default) @ opendistro_security_advanced_modules ---
[INFO] Building jar: /Opendistro/security-advanced-modules/target/opendistro_security_advanced_modules-0.9.0.4-tests.jar
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ opendistro_security_advanced_modules ---
[INFO] Installing /Opendistro/security-advanced-modules/target/opendistro_security_advanced_modules-0.9.0.4.jar to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security_advanced_modules/0.9.0.4/opendistro_security_advanced_modules-0.9.0.4.jar
[INFO] Installing /Opendistro/security-advanced-modules/pom.xml to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security_advanced_modules/0.9.0.4/opendistro_security_advanced_modules-0.9.0.4.pom
[INFO] Installing /Opendistro/security-advanced-modules/target/opendistro_security_advanced_modules-0.9.0.4-tests.jar to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security_advanced_modules/0.9.0.4/opendistro_security_advanced_modules-0.9.0.4-tests.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------