### PR TITLE
Opendistro 1.3

### DIFF
--- a/opendistro-elasticsearch-security-advanced-modules.release-notes
+++ b/opendistro-elasticsearch-security-advanced-modules.release-notes
@@ -1,6 +1,10 @@
-## 2019-08-07, Version 1.2.0.0 (Current)
+## 2019-10-10, Version 1.2.1.0 (Current)
 
-- Support for Elasticsearch 7.2
+- Support for Elasticsearch 7.2.1
+
+## 2019-08-07, Version 1.2.0.0
+
+- Support for Elasticsearch 7.2.0
 
 ## 2019-06-21, Version 1.1.0.0
 

--- a/opendistro-elasticsearch-security-advanced-modules.release-notes
+++ b/opendistro-elasticsearch-security-advanced-modules.release-notes
@@ -1,4 +1,22 @@
-## 2019-10-10, Version 1.2.1.0 (Current)
+## 2019-11-18 Version 1.3.0.0 (Current)
+
+- Support for Elasticsearch 7.3.2
+- Fixed leaked ldap connection
+- Use combine bitset for DLS
+- Fixed FLS exists query on fields without norms and doc values
+- Fixed field masking with aggregations
+- Introduced MaskedTermsEnum to fix field anonymization with aggregations
+- Added _seq_no and _primary_term to meta fields for FLS
+- Fixed rest API validator to accept opendistro_secuirty_roles for internal users
+- Exception handling for SAML IdP at startup
+- Updated Jackson databind dependency to 2.9.9
+- Updated Kafka client dependency to 2.0.1
+- Fixed access control exception for ldap2
+- Upgraded CXF to 2.3.9
+- Bumped jackson-databind from 2.9.9.2 to 2.9.10.1
+- Other minor fixes for detailed error logging
+
+## 2019-10-10, Version 1.2.1.0
 
 - Support for Elasticsearch 7.2.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <artifactId>opendistro_security_advanced_modules</artifactId>
-  <version>1.2.1.0</version>
+  <version>1.3.0.0</version>
   <packaging>jar</packaging>
 
   <name>Open Distro For Elasticsearch Advanced Modules</name>
@@ -33,8 +33,8 @@
   <inceptionYear>2016</inceptionYear>
 
   <properties>
-    <security.version>1.2.1.0</security.version>
-    <elasticsearch.version>7.2.1</elasticsearch.version>
+    <security.version>1.3.0.0</security.version>
+    <elasticsearch.version>7.3.2</elasticsearch.version>
 
     <!-- deps -->
     <log4j.version>2.11.1</log4j.version>
@@ -54,7 +54,7 @@
     <url>https://github.com/opendistro-for-elasticsearch/security-advanced-modules</url>
     <connection>scm:git:git@github.com:opendistro-for-elasticsearch/security-advanced-modules.git</connection>
     <developerConnection>scm:git:git@github.com:opendistro-for-elasticsearch/security-advanced-modules.git</developerConnection>
-    <tag>v1.2.1.0</tag>
+    <tag>v1.3.0.0</tag>
   </scm>
 
   <issueManagement>
@@ -206,7 +206,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>1.0.1</version>
+      <version>2.0.1</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-api</artifactId>
@@ -283,13 +283,13 @@
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka-test</artifactId>
-      <version>2.1.4.RELEASE</version>
+      <version>2.2.7.RELEASE</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>1.0.1</version>
+      <version>2.0.1</version>
       <scope>test</scope>
       <classifier>test</classifier>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
     <artifactId>opendistro_security_parent</artifactId>
-    <version>1.2.1.0</version>
+    <version>1.3.0.0</version>
   </parent>
 
   <artifactId>opendistro_security_advanced_modules</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,11 @@
   <parent>
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
     <artifactId>opendistro_security_parent</artifactId>
-    <version>1.2.0.0</version>
+    <version>1.2.1.0</version>
   </parent>
 
   <artifactId>opendistro_security_advanced_modules</artifactId>
-  <version>1.2.0.0</version>
+  <version>1.2.1.0</version>
   <packaging>jar</packaging>
 
   <name>Open Distro For Elasticsearch Advanced Modules</name>
@@ -33,8 +33,8 @@
   <inceptionYear>2016</inceptionYear>
 
   <properties>
-    <security.version>1.2.0.0</security.version>
-    <elasticsearch.version>7.2.0</elasticsearch.version>
+    <security.version>1.2.1.0</security.version>
+    <elasticsearch.version>7.2.1</elasticsearch.version>
 
     <!-- deps -->
     <log4j.version>2.11.1</log4j.version>
@@ -54,7 +54,7 @@
     <url>https://github.com/opendistro-for-elasticsearch/security-advanced-modules</url>
     <connection>scm:git:git@github.com:opendistro-for-elasticsearch/security-advanced-modules.git</connection>
     <developerConnection>scm:git:git@github.com:opendistro-for-elasticsearch/security-advanced-modules.git</developerConnection>
-    <tag>v1.2.0.0</tag>
+    <tag>v1.2.1.0</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <log4j.version>2.11.1</log4j.version>
     <jjwt.version>0.10.5</jjwt.version>
     <ldaptive.version>1.2.3</ldaptive.version>
-    <jackson-databind.version>2.9.9.2</jackson-databind.version>
+    <jackson-databind.version>2.9.10.1</jackson-databind.version>
     <http.commons.version>4.5.3</http.commons.version>
     <cxf.version>3.2.2</cxf.version>
     <guava.version>25.1-jre</guava.version>

--- a/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
@@ -111,7 +111,12 @@ public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
             this.metadataResolver = createMetadataResolver(settings, configPath);
 
             this.saml2SettingsProvider = new Saml2SettingsProvider(settings, this.metadataResolver);
-            this.saml2SettingsProvider.getCached();
+
+            try {
+                this.saml2SettingsProvider.getCached();
+            } catch (Exception e) {
+                log.debug("Exception while initializing Saml2SettingsProvider. Possibly, the IdP is unreachable right now. This is recoverable by a meta data refresh.", e);
+            }
 
             this.jwtSettings = this.createJwtAuthenticatorSettings(settings);
 

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthenticationBackend2.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthenticationBackend2.java
@@ -18,6 +18,7 @@ package com.amazon.dlic.auth.ldap2;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
@@ -83,6 +84,32 @@ public class LDAPAuthenticationBackend2 implements AuthenticationBackend, Destro
 
     @Override
     public User authenticate(final AuthCredentials credentials) throws ElasticsearchSecurityException {
+        final SecurityManager sm = System.getSecurityManager();
+
+        if (sm != null) {
+            sm.checkPermission(new SpecialPermission());
+        }
+
+        try {
+            return AccessController.doPrivileged(new PrivilegedExceptionAction<User>() {
+                @Override
+                public User run() throws Exception {
+                    return authenticate0(credentials);
+                }
+            });
+        } catch (PrivilegedActionException e) {
+            if (e.getException() instanceof ElasticsearchSecurityException) {
+                throw (ElasticsearchSecurityException) e.getException();
+            } else if (e.getException() instanceof RuntimeException) {
+                throw (RuntimeException) e.getException();
+            } else {
+                throw new RuntimeException(e.getException());
+            }
+        }
+    }
+
+
+    private User authenticate0(final AuthCredentials credentials) throws ElasticsearchSecurityException {
 
         Connection ldapConnection = null;
         final String user = credentials.getUsername();
@@ -157,6 +184,23 @@ public class LDAPAuthenticationBackend2 implements AuthenticationBackend, Destro
 
     @Override
     public boolean exists(final User user) {
+        final SecurityManager sm = System.getSecurityManager();
+
+        if (sm != null) {
+            sm.checkPermission(new SpecialPermission());
+        }
+
+
+        return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+            @Override
+            public Boolean run() {
+                return exists0(user);
+            }
+        });
+
+    }
+
+    private boolean exists0(final User user) {
         Connection ldapConnection = null;
         String userName = user.getName();
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/MaskedField.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/MaskedField.java
@@ -77,6 +77,10 @@ public class MaskedField {
     }
 
     public BytesRef mask(BytesRef value) {
+        if(value == null) {
+            return null;
+        }
+
         if (isDefault()) {
             return blake2bHash(value);
         } else {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityFlsDlsIndexSearcherWrapper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityFlsDlsIndexSearcherWrapper.java
@@ -21,16 +21,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.LongSupplier;
 
-import com.amazon.opendistroforelasticsearch.security.privileges.PrivilegesEvaluator;
 import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.join.BitSetProducer;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
-import org.elasticsearch.index.engine.EngineException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardUtils;
@@ -38,17 +33,16 @@ import org.elasticsearch.index.shard.ShardUtils;
 import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog;
 import com.amazon.opendistroforelasticsearch.security.compliance.ComplianceConfig;
 import com.amazon.opendistroforelasticsearch.security.compliance.ComplianceIndexingOperationListener;
-import com.amazon.opendistroforelasticsearch.security.configuration.AdminDNs;
-import com.amazon.opendistroforelasticsearch.security.configuration.EmptyFilterLeafReader;
-import com.amazon.opendistroforelasticsearch.security.configuration.OpenDistroSecurityIndexSearcherWrapper;
+import com.amazon.opendistroforelasticsearch.security.privileges.PrivilegesEvaluator;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.HeaderHelper;
 import com.amazon.opendistroforelasticsearch.security.support.OpenDistroSecurityUtils;
+
 import com.google.common.collect.Sets;
 
 public class OpenDistroSecurityFlsDlsIndexSearcherWrapper extends OpenDistroSecurityIndexSearcherWrapper {
 
-    private static final Set<String> metaFields = Sets.union(Sets.newHashSet("_source", "_version"),
+    private static final Set<String> metaFields = Sets.union(Sets.newHashSet("_source", "_version", "_field_names", "_seq_no", "_primary_term"),
             Sets.newHashSet(MapperService.getAllMetaFields()));
     private final ClusterService clusterService;
     private final IndexService indexService;
@@ -81,7 +75,7 @@ public class OpenDistroSecurityFlsDlsIndexSearcherWrapper extends OpenDistroSecu
 
         Set<String> flsFields = null;
         Set<String> maskedFields = null;
-        BitSetProducer bsp = null;
+        Query dlsQuery = null;
 
         if(!isAdmin) {
 
@@ -108,9 +102,8 @@ public class OpenDistroSecurityFlsDlsIndexSearcherWrapper extends OpenDistroSecu
                 if(unparsedDlsQueries != null && !unparsedDlsQueries.isEmpty()) {
                     final BitsetFilterCache bsfc = this.indexService.cache().bitsetFilterCache();
                     //disable reader optimizations
-                    final Query dlsQuery = DlsQueryParser.parse(unparsedDlsQueries, this.indexService.newQueryShardContext(shardId.getId(), null, nowInMillis, null)
+                    dlsQuery = DlsQueryParser.parse(unparsedDlsQueries, this.indexService.newQueryShardContext(shardId.getId(), null, nowInMillis, null)
                             , this.indexService.xContentRegistry());
-                    bsp = dlsQuery==null?null:bsfc.getBitSetProducer(dlsQuery);
                 }
             }
 
@@ -122,17 +115,5 @@ public class OpenDistroSecurityFlsDlsIndexSearcherWrapper extends OpenDistroSecu
 
         return new DlsFlsFilterLeafReader.DlsFlsDirectoryReader(reader, flsFields, bsp,
                 indexService, threadContext, clusterService, complianceConfig, auditlog, maskedFields, shardId);
-    }
-
-
-    @Override
-    protected IndexSearcher dlsFlsWrap(final IndexSearcher searcher, boolean isAdmin) throws EngineException {
-
-        if(searcher.getIndexReader().getClass() != DlsFlsFilterLeafReader.DlsFlsDirectoryReader.class
-                && searcher.getIndexReader().getClass() != EmptyFilterLeafReader.EmptyDirectoryReader.class) {
-            throw new RuntimeException("Unexpected index reader class "+searcher.getIndexReader().getClass());
-        }
-
-        return searcher;
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityFlsDlsIndexSearcherWrapper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityFlsDlsIndexSearcherWrapper.java
@@ -100,7 +100,6 @@ public class OpenDistroSecurityFlsDlsIndexSearcherWrapper extends OpenDistroSecu
             if (dlsEval != null) {
                 final Set<String> unparsedDlsQueries = queries.get(dlsEval);
                 if(unparsedDlsQueries != null && !unparsedDlsQueries.isEmpty()) {
-                    final BitsetFilterCache bsfc = this.indexService.cache().bitsetFilterCache();
                     //disable reader optimizations
                     dlsQuery = DlsQueryParser.parse(unparsedDlsQueries, this.indexService.newQueryShardContext(shardId.getId(), null, nowInMillis, null)
                             , this.indexService.xContentRegistry());
@@ -113,7 +112,7 @@ public class OpenDistroSecurityFlsDlsIndexSearcherWrapper extends OpenDistroSecu
             }
         }
 
-        return new DlsFlsFilterLeafReader.DlsFlsDirectoryReader(reader, flsFields, bsp,
+        return new DlsFlsFilterLeafReader.DlsFlsDirectoryReader(reader, flsFields, dlsQuery,
                 indexService, threadContext, clusterService, complianceConfig, auditlog, maskedFields, shardId);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityFlsDlsIndexSearcherWrapper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityFlsDlsIndexSearcherWrapper.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.LongSupplier;
 
+import com.amazon.opendistroforelasticsearch.security.privileges.PrivilegesEvaluator;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -57,8 +58,8 @@ public class OpenDistroSecurityFlsDlsIndexSearcherWrapper extends OpenDistroSecu
 
     public OpenDistroSecurityFlsDlsIndexSearcherWrapper(final IndexService indexService, final Settings settings,
             final AdminDNs adminDNs, final ClusterService clusterService, final AuditLog auditlog,
-            final ComplianceIndexingOperationListener ciol, final ComplianceConfig complianceConfig) {
-        super(indexService, settings, adminDNs);
+            final ComplianceIndexingOperationListener ciol, final ComplianceConfig complianceConfig, final PrivilegesEvaluator evaluator) {
+        super(indexService, settings, adminDNs, evaluator);
         ciol.setIs(indexService);
         this.clusterService = clusterService;
         this.indexService = indexService;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
@@ -348,7 +348,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 		// not 400
 		consumeParameters(request);
 
-		// check if SG index has been initialized
+		// check if .opendistro_security index has been initialized
 		if (!ensureIndexExists()) {
 			return channel -> internalErrorResponse(channel, ErrorType.SECURITY_NOT_INITIALIZED.getMessage());
 		}
@@ -512,7 +512,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 	/**
 	 * Consume all defined parameters for the request. Before we handle the
 	 * request in subclasses where we actually need the parameter, some global
-	 * checks are performed, e.g. check whether the SG index exists. Thus, the
+	 * checks are performed, e.g. check whether the .security_index index exists. Thus, the
 	 * parameter(s) have not been consumed, and ES will always return a 400 with
 	 * an internal error message.
 	 *

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
@@ -109,7 +109,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 		try {
 			// validate additional settings, if any
 			AbstractConfigurationValidator validator = getValidator(request, request.content());
-			if (!validator.validateSettings()) {
+			if (!validator.validate()) {
 				request.params().clear();
 				badRequestResponse(channel, validator);
 				return;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/OpenDistroSecurityConfigAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/OpenDistroSecurityConfigAction.java
@@ -62,7 +62,7 @@ public class OpenDistroSecurityConfigAction extends PatchableResourceApiAction {
 
         if(allowPutOrPatch) {
 
-            //deprecated, will be removed with SG 8, use opendistro_security_config instead of sgconfig
+            //deprecated, will be removed with ODFE 8, use opendistro_security_config instead of config
             controller.registerHandler(Method.PUT, "/_opendistro/_security/api/securityconfig/{name}", this);
             controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/securityconfig/", this);
 
@@ -74,7 +74,6 @@ public class OpenDistroSecurityConfigAction extends PatchableResourceApiAction {
 
     @Override
     protected void handleGet(RestChannel channel, RestRequest request, Client client, final JsonNode content) throws IOException{
-        //final SgDynamicConfiguration<?> configuration = load(getConfigName(), true);
         final SecurityDynamicConfiguration<?> configuration = load(getConfigName(), true);
 
         filter(configuration);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
@@ -131,7 +131,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
         AbstractConfigurationValidator originalValidator = postProcessApplyPatchResult(channel, request, existingResourceAsJsonNode, patchedResourceAsJsonNode, name);
 
         if(originalValidator != null) {
-            if (!originalValidator.validateSettings()) {
+            if (!originalValidator.validate()) {
                 request.params().clear();
                 badRequestResponse(channel, originalValidator);
                 return;
@@ -141,7 +141,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
 
         AbstractConfigurationValidator validator = getValidator(request, patchedResourceAsJsonNode);
 
-        if (!validator.validateSettings()) {
+        if (!validator.validate()) {
             request.params().clear();
                 badRequestResponse(channel, validator);
             return;
@@ -203,7 +203,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
             AbstractConfigurationValidator originalValidator = postProcessApplyPatchResult(channel, request, oldResource, patchedResource, resourceName);
 
             if(originalValidator != null) {
-                if (!originalValidator.validateSettings()) {
+                if (!originalValidator.validate()) {
                     request.params().clear();
                         badRequestResponse(channel, originalValidator);
                     return;
@@ -213,7 +213,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
             if (oldResource == null || !oldResource.equals(patchedResource)) {
                 AbstractConfigurationValidator validator = getValidator(request, patchedResource);
 
-                if (!validator.validateSettings()) {
+                if (!validator.validate()) {
                     request.params().clear();
                         badRequestResponse(channel, validator);
                     return;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/support/Utils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/support/Utils.java
@@ -16,11 +16,15 @@
 package com.amazon.opendistroforelasticsearch.security.dlic.rest.support;
 
 import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -29,12 +33,16 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.amazon.opendistroforelasticsearch.security.DefaultObjectMapper;
 import com.amazon.opendistroforelasticsearch.security.support.OpenDistroSecurityDeprecationHandler;
 
 public class Utils {
+
+    private static final ObjectMapper internalMapper = new ObjectMapper();
 
     public static Map<String, Object> convertJsonToxToStructuredMap(ToXContent jsonContent) {
         Map<String, Object> map = null;
@@ -117,5 +125,57 @@ public class Utils {
             throw ExceptionsHelper.convertToElastic(e1);
         }
 
+    }
+
+    public static byte[] jsonMapToByteArray(Map<String, Object> jsonAsMap) throws IOException {
+
+        final SecurityManager sm = System.getSecurityManager();
+
+        if (sm != null) {
+            sm.checkPermission(new SpecialPermission());
+        }
+
+        try {
+            return AccessController.doPrivileged(new PrivilegedExceptionAction<byte[]>() {
+                @Override
+                public byte[] run() throws Exception {
+                    return internalMapper.writeValueAsBytes(jsonAsMap);
+                }
+            });
+        } catch (final PrivilegedActionException e) {
+            if (e.getCause() instanceof JsonProcessingException) {
+                throw (JsonProcessingException) e.getCause();
+            } else if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            } else {
+                throw new RuntimeException(e.getCause());
+            }
+        }
+    }
+
+    public static Map<String, Object> byteArrayToMutableJsonMap(byte[] jsonBytes) throws IOException {
+
+        final SecurityManager sm = System.getSecurityManager();
+
+        if (sm != null) {
+            sm.checkPermission(new SpecialPermission());
+        }
+
+        try {
+            return AccessController.doPrivileged(new PrivilegedExceptionAction<Map<String, Object>>() {
+                @Override
+                public Map<String, Object> run() throws Exception {
+                    return internalMapper.readValue(jsonBytes, new TypeReference<Map<String, Object>>() {});
+                }
+            });
+        } catch (final PrivilegedActionException e) {
+            if (e.getCause() instanceof IOException) {
+                throw (IOException) e.getCause();
+            } else if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            } else {
+                throw new RuntimeException(e.getCause());
+            }
+        }
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/InternalUsersValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/InternalUsersValidator.java
@@ -40,11 +40,12 @@ public class InternalUsersValidator extends AbstractConfigurationValidator {
         allowedKeys.put("backend_roles", DataType.ARRAY);
         allowedKeys.put("attributes", DataType.OBJECT);
         allowedKeys.put("description", DataType.STRING);
+        allowedKeys.put("opendistro_security_roles", DataType.ARRAY);
     }
 
     @Override
-    public boolean validateSettings() {
-        if(!super.validateSettings()) {
+    public boolean validate() {
+        if(!super.validate()) {
             return false;
         }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/RolesValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/RolesValidator.java
@@ -37,9 +37,9 @@ public class RolesValidator extends AbstractConfigurationValidator {
 	}
 
     @Override
-    public boolean validateSettings() {
+    public boolean validate() {
 
-        if (!super.validateSettings()) {
+        if (!super.validate()) {
             return false;
         }
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -157,4 +157,21 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 		Assert.assertNull(creds);
 	}
 
+	@Test
+	public void testPeculiarJsonEscaping() {
+		Settings settings = Settings.builder().put("openid_connect_url", mockIdpServer.getDiscoverUri()).build();
+
+		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
+
+		AuthCredentials creds = jwtAuth.extractCredentials(
+				new FakeRestRequest(ImmutableMap.of("Authorization", TestJwts.PeculiarEscaping.MC_COY_SIGNED_RSA_1), new HashMap<String, String>()),
+				null);
+
+		Assert.assertNotNull(creds);
+		Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
+		Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
+		Assert.assertEquals(0, creds.getBackendRoles().size());
+		Assert.assertEquals(3, creds.getAttributes().size());
+	}
+
 }

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SelfRefreshingKeySetTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SelfRefreshingKeySetTest.java
@@ -35,16 +35,16 @@ public class SelfRefreshingKeySetTest {
 	public void basicTest() throws AuthenticatorUnavailableException, BadCredentialsException {
 		SelfRefreshingKeySet selfRefreshingKeySet = new SelfRefreshingKeySet(new MockKeySetProvider());
 
-		JsonWebKey key1 = selfRefreshingKeySet.getKey("kid_a");
+		JsonWebKey key1 = selfRefreshingKeySet.getKey("kid/a");
 		Assert.assertEquals(TestJwk.OCT_1_K, key1.getProperty("k"));
 		Assert.assertEquals(1, selfRefreshingKeySet.getRefreshCount());
 
-		JsonWebKey key2 = selfRefreshingKeySet.getKey("kid_b");
+		JsonWebKey key2 = selfRefreshingKeySet.getKey("kid/b");
 		Assert.assertEquals(TestJwk.OCT_2_K, key2.getProperty("k"));
 		Assert.assertEquals(1, selfRefreshingKeySet.getRefreshCount());
 
 		try {
-			selfRefreshingKeySet.getKey("kid_X");
+			selfRefreshingKeySet.getKey("kid/X");
 			Assert.fail("Expected a BadCredentialsException");
 		} catch (BadCredentialsException e) {
 			Assert.assertEquals(2, selfRefreshingKeySet.getRefreshCount());
@@ -62,11 +62,11 @@ public class SelfRefreshingKeySetTest {
 
 		ExecutorService executorService = Executors.newCachedThreadPool();
 
-		Future<JsonWebKey> f1 = executorService.submit(() -> selfRefreshingKeySet.getKey("kid_a"));
+		Future<JsonWebKey> f1 = executorService.submit(() -> selfRefreshingKeySet.getKey("kid/a"));
 
 		provider.waitForCalled();
 
-		Future<JsonWebKey> f2 = executorService.submit(() -> selfRefreshingKeySet.getKey("kid_b"));
+		Future<JsonWebKey> f2 = executorService.submit(() -> selfRefreshingKeySet.getKey("kid/b"));
 
 		while (selfRefreshingKeySet.getQueuedGetCount() == 0) {
 			Thread.sleep(10);

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwk.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwk.java
@@ -30,9 +30,9 @@ class TestJwk {
 	static final String OCT_2_K = "YP6Q3IF2qJEagV948dsicXKpG43Ci2W7ZxUpiVTBLZr1vFN9ZGUKxeXGgVWuMFYTmoHvv5AOC8BvoNOpcE3rcJNuNOqTMdujxD92CxjOykiLEKQ0Te_7xQ4LnSQjlqdIJ4U3S7qCnJLd1LxhKOGZcUhE_pjhwf7q2RUUpvC3UOyZZLog9yeflnp9nqqDy5yVqRYWZRcPI06kJTh3Z8IFi2JRJV14iUFQtOHQKuyJRMcsldKnfWl7YW3JdQ9IRN-c1lEYSEBmsavEejcqHZkbli2svqLfmCBJVWffXDRxhq0_VafiL83HC0bP9qeNKivhemw6foVmg8UMs7yJ6ao02A";
 	static final String OCT_3_K = "r3aeW3OK7-B4Hs3hq9BmlT1D3jRiolH9PL82XUz9xAS7dniAdmvMnN5GkOc1vqibOe2T-CC_103UglDm9D0iU9S9zn6wTuQt1L5wfZIoHd9f5IjJ_YFEzZMvsoUY_-ji_0K_ugVvBPwi9JnBQHHS4zrgmP06dGjmcnZDcIf4W_iFas3lDYSXilL1V2QhNaynpSqTarpfBGSphKv4Zg2JhsX8xB0VSaTlEq4lF8pzvpWSxXCW9CtomhB80daSuTizrmSTEPpdN3XzQ2-Tovo1ieMOfDU4csvjEk7Bwc2ThjpnA8ucKQUYpUv9joBxKuCdUltssthWnetrogjYOn_xGA";
 
-	static final JsonWebKey OCT_1 = createOct("kid_a", "HS256", OCT_1_K);
-	static final JsonWebKey OCT_2 = createOct("kid_b", "HS256", OCT_2_K);
-	static final JsonWebKey OCT_3 = createOct("kid_c", "HS256", OCT_3_K);
+	static final JsonWebKey OCT_1 = createOct("kid/a", "HS256", OCT_1_K);
+	static final JsonWebKey OCT_2 = createOct("kid/b", "HS256", OCT_2_K);
+	static final JsonWebKey OCT_3 = createOct("kid/c", "HS256", OCT_3_K);
 	static final JsonWebKey ESCAPED_SLASH_KID_OCT_1 = createOct("kid\\/_a", "HS256", OCT_1_K);
 	static final JsonWebKey FORWARD_SLASH_KID_OCT_1 = createOct("kid/_a", "HS256", OCT_1_K);
 
@@ -50,16 +50,16 @@ class TestJwk {
 	static final String RSA_X_N = "jDDVUMXOXDVcaRVAT5TtuiAsLxk7XAAwyyECfmySZul7D5XVLMtGe6rP2900q3nM4BaCEiuwXjmTCZDAGlFGs2a3eQ1vbBSv9_0KGHL-gZGFPNiv0v8aR7QzZ-abhGnRy5F52PlTWsypGgG_kQpF2t2TBotvYhvVPagAt4ljllDKvY1siOvS3nh4TqcUtWcbgQZEWPmaXuhx0eLmhQJca7UEw99YlGNew48AEzt7ZnfU0Qkz3JwSz7IcPx-NfIh6BN6LwAg_ASdoM3MR8rDOtLYavmJVhutrfOpE-4-fw1mf3eLYu7xrxIplSiOIsHunTUssnTiBkXAaGqGJs604Pw";
 	static final String RSA_X_E = "AQAB";
 
-	static final JsonWebKey RSA_1 = createRsa("kid_1", "RS256", RSA_1_E, RSA_1_N, RSA_1_D);
-	static final JsonWebKey RSA_1_PUBLIC = createRsaPublic("kid_1", "RS256", RSA_1_E, RSA_1_N);
-	static final JsonWebKey RSA_1_PUBLIC_NO_ALG = createRsaPublic("kid_1", null, RSA_1_E, RSA_1_N);
-    static final JsonWebKey RSA_1_PUBLIC_WRONG_ALG = createRsaPublic("kid_1", "HS256", RSA_1_E, RSA_1_N);
+	static final JsonWebKey RSA_1 = createRsa("kid/1", "RS256", RSA_1_E, RSA_1_N, RSA_1_D);
+	static final JsonWebKey RSA_1_PUBLIC = createRsaPublic("kid/1", "RS256", RSA_1_E, RSA_1_N);
+	static final JsonWebKey RSA_1_PUBLIC_NO_ALG = createRsaPublic("kid/1", null, RSA_1_E, RSA_1_N);
+    static final JsonWebKey RSA_1_PUBLIC_WRONG_ALG = createRsaPublic("kid/1", "HS256", RSA_1_E, RSA_1_N);
 
-	static final JsonWebKey RSA_2 = createRsa("kid_2", "RS256", RSA_2_E, RSA_2_N, RSA_2_D);
-	static final JsonWebKey RSA_2_PUBLIC = createRsaPublic("kid_2", "RS256", RSA_2_E, RSA_2_N);
+	static final JsonWebKey RSA_2 = createRsa("kid/2", "RS256", RSA_2_E, RSA_2_N, RSA_2_D);
+	static final JsonWebKey RSA_2_PUBLIC = createRsaPublic("kid/2", "RS256", RSA_2_E, RSA_2_N);
 
-	static final JsonWebKey RSA_X = createRsa("kid_2", "RS256", RSA_X_E, RSA_X_N, RSA_X_D);
-	static final JsonWebKey RSA_X_PUBLIC = createRsaPublic("kid_2", "RS256", RSA_X_E, RSA_X_N);
+	static final JsonWebKey RSA_X = createRsa("kid/2", "RS256", RSA_X_E, RSA_X_N, RSA_X_D);
+	static final JsonWebKey RSA_X_PUBLIC = createRsaPublic("kid/2", "RS256", RSA_X_E, RSA_X_N);
 
 	static final JsonWebKeys RSA_1_2_PUBLIC = createJwks(RSA_1_PUBLIC, RSA_2_PUBLIC);
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
@@ -58,6 +58,10 @@ class TestJwts {
 		static final String MC_COY_SIGNED_RSA_X = createSignedWithoutKeyId(MC_COY, TestJwk.RSA_X);
 	}
 
+	static class PeculiarEscaping {
+		static final String MC_COY_SIGNED_RSA_1 = createSignedWithPeculiarEscaping(MC_COY, TestJwk.RSA_1);
+	}
+
 	static JwtToken create(String subject, String audience, Object... moreClaims) {
 		JwtClaims claims = new JwtClaims();
 
@@ -94,4 +98,16 @@ class TestJwts {
 
 		return new JoseJwtProducer().processJwt(signedToken, null, JwsUtils.getSignatureProvider(jwk));
 	}
+
+	static String createSignedWithPeculiarEscaping(JwtToken baseJwt, JsonWebKey jwk) {
+		JwsSignatureProvider signatureProvider = JwsUtils.getSignatureProvider(jwk);
+		JwsHeaders jwsHeaders = new JwsHeaders();
+		JwtToken signedToken = new JwtToken(jwsHeaders, baseJwt.getClaims());
+
+		// Depends on CXF not escaping the input string. This may fail for other frameworks or versions.
+		jwsHeaders.setKeyId(jwk.getKeyId().replace("/", "\\/"));
+
+		return new JoseJwtProducer().processJwt(signedToken, null, signatureProvider);
+	}
+
 }

--- a/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
@@ -485,6 +485,7 @@ public class HTTPSamlAuthenticatorTest {
 
             Assert.assertEquals("horst", jwt.getClaim("sub"));
         }
+    }
 
     private AuthenticateHeaders getAutenticateHeaders(HTTPSamlAuthenticator samlAuthenticator) {
         RestRequest restRequest = new FakeRestRequest(ImmutableMap.of(), new HashMap<String, String>());
@@ -580,11 +581,6 @@ public class HTTPSamlAuthenticatorTest {
 
         @Override
         public XContentBuilder newBuilder(XContentType xContentType, boolean useFiltering) throws IOException {
-            return null;
-        }
-
-        @Override
-        public XContentBuilder newBuilder(XContentType xContentType, XContentType xType, boolean useFiltering) throws IOException {
             return null;
         }
 

--- a/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
@@ -534,6 +534,11 @@ public class HTTPSamlAuthenticatorTest {
         }
 
         @Override
+        public XContentBuilder newBuilder(XContentType xContentType, XContentType xType, boolean useFiltering) throws IOException {
+            return null;
+        }
+
+        @Override
         public BytesStreamOutput bytesOutput() {
             return null;
         }

--- a/src/test/java/com/amazon/dlic/auth/http/saml/MockSamlIdpServer.java
+++ b/src/test/java/com/amazon/dlic/auth/http/saml/MockSamlIdpServer.java
@@ -181,7 +181,11 @@ class MockSamlIdpServer implements Closeable {
     private String defaultAssertionConsumerService;
 
     MockSamlIdpServer() throws IOException {
-        this(SocketUtils.findAvailableTcpPort(), false, ENTITY_ID, null);
+        this(SocketUtils.findAvailableTcpPort());
+    }
+
+    MockSamlIdpServer(int port) throws IOException {
+        this(port, false, ENTITY_ID, null);
     }
 
     MockSamlIdpServer(int port, boolean ssl, String idpEntityId, String endpointQueryString) throws IOException {
@@ -248,6 +252,9 @@ class MockSamlIdpServer implements Closeable {
         }
 
         this.httpServer = serverBootstrap.create();
+    }
+
+    public void start() throws IOException {
 
         httpServer.start();
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/routing/FallbackTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/routing/FallbackTest.java
@@ -126,7 +126,7 @@ public class FallbackTest extends AbstractAuditlogiUnitTest {
 		List<AuditLogSink> allSinks = router.categorySinks.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
 		allSinks = allSinks.stream().filter(sink -> (sink instanceof LoggingSink)).collect(Collectors.toList());
 		allSinks.removeAll(Collections.singleton(router.defaultSink));
-		allSinks.remove(router.categorySinks.get(exclude));
+		allSinks.removeAll(router.categorySinks.get(exclude));
 		for(AuditLogSink sink : allSinks) {
 			LoggingSink loggingSink = (LoggingSink)sink;
 			Assert.assertEquals(0, loggingSink.messages.size());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/sink/KafkaSinkTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/sink/KafkaSinkTest.java
@@ -40,7 +40,7 @@ import com.amazon.opendistroforelasticsearch.security.test.helper.file.FileHelpe
 public class KafkaSinkTest extends AbstractAuditlogiUnitTest {
 
 	@ClassRule
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, 1, "compliance");
+	public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, true, 1, "compliance");
 
 	@Test
 	public void testKafka() throws Exception {
@@ -57,7 +57,7 @@ public class KafkaSinkTest extends AbstractAuditlogiUnitTest {
 	            Assert.assertEquals(KafkaSink.class, sink.getClass());
     	        boolean success = sink.doStore(MockAuditMessageFactory.validAuditMessage(Category.MISSING_PRIVILEGES));
     	        Assert.assertTrue(success);
-    	        ConsumerRecords<Long, String> records = consumer.poll(10000);
+    	        ConsumerRecords<Long, String> records = consumer.poll(Duration.ofSeconds(10));
     	        Assert.assertEquals(1, records.count());
 	        } finally {
 	            sink.close();
@@ -68,7 +68,7 @@ public class KafkaSinkTest extends AbstractAuditlogiUnitTest {
 
 	private KafkaConsumer<Long, String> createConsumer() {
 		Properties props = new Properties();
-		props.put("bootstrap.servers", embeddedKafka.getBrokersAsString());
+		props.put("bootstrap.servers", embeddedKafka.getEmbeddedKafka().getBrokersAsString());
 		props.put("auto.offset.reset", "earliest");
 		props.put("group.id", "mygroup"+System.currentTimeMillis()+"_"+new Random().nextDouble());
 		props.put("key.deserializer", "org.apache.kafka.common.serialization.LongDeserializer");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/sink/KafkaSinkTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/sink/KafkaSinkTest.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.security.auditlog.sink;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -25,6 +26,7 @@ import org.elasticsearch.common.xcontent.yaml.YamlXContent;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.kafka.test.rule.KafkaEmbedded;
 
 import scala.util.Random;
@@ -45,7 +47,7 @@ public class KafkaSinkTest extends AbstractAuditlogiUnitTest {
 	@Test
 	public void testKafka() throws Exception {
 	    String configYml = FileHelper.loadFile("auditlog/endpoints/sink/configuration_kafka.yml");
-	    configYml = configYml.replace("_RPLC_BOOTSTRAP_SERVERS_",embeddedKafka.getBrokersAsString());
+		configYml = configYml.replace("_RPLC_BOOTSTRAP_SERVERS_",embeddedKafka.getEmbeddedKafka().getBrokersAsString());
 		Settings.Builder settingsBuilder = Settings.builder().loadFromSource(configYml, YamlXContent.yamlXContent.type());
 		try(KafkaConsumer<Long, String> consumer = createConsumer()) {
 		    consumer.subscribe(Arrays.asList("compliance"));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/dlsfls/DlsScrollTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/dlsfls/DlsScrollTest.java
@@ -8,8 +8,8 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.floragunn.searchguard.test.helper.file.FileHelper;
-import com.floragunn.searchguard.test.helper.rest.RestHelper.HttpResponse;
+import com.amazon.opendistroforelasticsearch.security.test.helper.file.FileHelper;
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 public class DlsScrollTest extends AbstractDlsFlsTest{
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/dlsfls/DlsScrollTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/dlsfls/DlsScrollTest.java
@@ -1,0 +1,67 @@
+package com.amazon.opendistroforelasticsearch.security.dlic.dlsfls;
+
+import org.apache.http.HttpStatus;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.floragunn.searchguard.test.helper.file.FileHelper;
+import com.floragunn.searchguard.test.helper.rest.RestHelper.HttpResponse;
+
+public class DlsScrollTest extends AbstractDlsFlsTest{
+
+
+    @Override
+    protected void populateData(TransportClient tc) {
+
+        tc.index(new IndexRequest("deals").type("deals").id("0").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source("{\"amount\": 3}", XContentType.JSON)).actionGet(); //not in
+
+        tc.index(new IndexRequest("deals").type("deals").id("1").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source("{\"amount\": 10}", XContentType.JSON)).actionGet(); //not in
+
+        tc.index(new IndexRequest("deals").type("deals").id("2").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source("{\"amount\": 1500}", XContentType.JSON)).actionGet();
+
+        tc.index(new IndexRequest("deals").type("deals").id("4").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source("{\"amount\": 21500}", XContentType.JSON)).actionGet(); //not in
+
+        for(int i=0; i<100; i++) {
+            tc.index(new IndexRequest("deals").type("deals").id("gen"+i).setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                    .source("{\"amount\": 1500}", XContentType.JSON)).actionGet();
+        }
+    }
+
+
+    @Test
+    public void testDlsScroll() throws Exception {
+
+        setup();
+
+        HttpResponse res;
+        Assert.assertEquals(HttpStatus.SC_OK, (res=rh.executeGetRequest("/deals/_search?scroll=1m&pretty=true&size=5", encodeBasicHeader("dept_manager", "password"))).getStatusCode());
+        Assert.assertTrue(res.getBody().contains("\"value\" : 101,"));
+
+        int c=0;
+
+        while(true) {
+            int start = res.getBody().indexOf("_scroll_id") + 15;
+            String scrollid = res.getBody().substring(start, res.getBody().indexOf("\"", start+1));
+            Assert.assertEquals(HttpStatus.SC_OK, (res=rh.executePostRequest("/_search/scroll?pretty=true", "{\"scroll\" : \"1m\", \"scroll_id\" : \""+scrollid+"\"}", encodeBasicHeader("dept_manager", "password"))).getStatusCode());
+            Assert.assertTrue(res.getBody().contains("\"value\" : 101,"));
+            Assert.assertFalse(res.getBody().contains("\"amount\" : 3"));
+            Assert.assertFalse(res.getBody().contains("\"amount\" : 10"));
+            Assert.assertFalse(res.getBody().contains("\"amount\" : 21500"));
+            c++;
+
+            if(res.getBody().contains("\"hits\" : [ ]")) {
+                break;
+            }
+        }
+
+        Assert.assertEquals(21, c);
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/dlsfls/FlsDlsTestMulti.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/dlsfls/FlsDlsTestMulti.java
@@ -208,4 +208,66 @@ public class FlsDlsTestMulti extends AbstractDlsFlsTest{
         Assert.assertTrue(res.getBody().contains("\"amount\" : 20"));
         Assert.assertTrue(res.getBody().contains("\"found\" : false"));
     }
+
+    @Test
+    public void testDlsSuggest() throws Exception {
+
+        setup();
+
+        HttpResponse res;
+        String query =
+
+                "{"+
+                        "\"query\": {"+
+                        "\"range\" : {"+
+                        "\"amount\" : {"+
+                        "\"gte\" : 11,"+
+                        "\"lte\" : 50000,"+
+                        "\"boost\" : 1.0"+
+                        "}"+
+                        "}"+
+                        "},"+
+                        "\"suggest\" : {\n" +
+                        "    \"thesuggestion\" : {\n" +
+                        "      \"text\" : \"cust\",\n" +
+                        "      \"term\" : {\n" +
+                        "        \"field\" : \"customer.name\"\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }"+
+                        "}";
+
+        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode());
+        Assert.assertTrue(res.getBody().contains("thesuggestion"));
+
+        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_multi", "password"))).getStatusCode());
+        Assert.assertTrue(res.getBody().contains("thesuggestion"));
+    }
+
+    @Test
+    public void testDlsSuggestOnly() throws Exception {
+
+        setup();
+
+        HttpResponse res;
+        String query =
+
+                "{"+
+                        "\"suggest\" : {\n" +
+                        "    \"thesuggestion\" : {\n" +
+                        "      \"text\" : \"cust\",\n" +
+                        "      \"term\" : {\n" +
+                        "        \"field\" : \"customer.name\"\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }"+
+                        "}";
+
+        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode());
+        Assert.assertTrue(res.getBody().contains("thesuggestion"));
+
+        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_multi", "password"))).getStatusCode());
+        Assert.assertTrue(res.getBody().contains("thesuggestion"));
+    }
+
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/dlsfls/FlsExistsFieldsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/dlsfls/FlsExistsFieldsTest.java
@@ -1,0 +1,104 @@
+package com.amazon.opendistroforelasticsearch.security.dlic.dlsfls;
+
+import org.apache.http.HttpStatus;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+public class FlsExistsFieldsTest extends AbstractDlsFlsTest {
+
+    protected void populateData(TransportClient tc) {
+
+        tc.admin().indices().create(new CreateIndexRequest("data").mapping("doc",
+                "@timestamp", "type=date",
+                "host", "type=text,norms=false",
+                "response", "type=text,norms=false",
+                "non-existing", "type=text,norms=false"
+        ))
+                .actionGet();
+
+        for (int i = 0; i < 1; i++) {
+            String doc = "{\"host\" : \"myhost"+i+"\",\n" +
+                    "        \"@timestamp\" : \"2018-01-18T09:03:25.877Z\",\n" +
+                    "        \"response\": \"404\"}";
+            tc.index(new IndexRequest("data").type("doc").id("a-normal-" + i).setRefreshPolicy(RefreshPolicy.IMMEDIATE).source(doc,
+                    XContentType.JSON)).actionGet();
+        }
+
+        for (int i = 0; i < 1; i++) {
+            String doc = "{" +
+                    "        \"@timestamp\" : \"2017-01-18T09:03:25.877Z\",\n" +
+                    "        \"response\": \"200\"}";
+            tc.index(new IndexRequest("data").type("doc").id("b-missing1-" + i).setRefreshPolicy(RefreshPolicy.IMMEDIATE).source(doc,
+                    XContentType.JSON)).actionGet();
+        }
+
+        for (int i = 0; i < 1; i++) {
+            String doc = "{\"host\" : \"myhost"+i+"\",\n" +
+                    "        \"@timestamp\" : \"2018-01-18T09:03:25.877Z\",\n" +
+                    "         \"non-existing\": \"xxx\","+
+                    "        \"response\": \"403\"}";
+            tc.index(new IndexRequest("data").type("doc").id("c-missing2-" + i).setRefreshPolicy(RefreshPolicy.IMMEDIATE).source(doc,
+                    XContentType.JSON)).actionGet();
+        }
+
+    }
+
+    @Test
+    public void testExistsField() throws Exception {
+        setup();
+
+        String query = "{\n" +
+                "  \"query\": {\n" +
+                "    \"bool\": {\n" +
+
+                "      \"must_not\": \n" +
+                "      {\n" +
+                "          \"exists\": {\n" +
+                "            \"field\": \"non-existing\"\n" +
+                "            \n" +
+                "          }\n" +
+                "      },\n" +
+
+                "      \"must\": [\n" +
+                "        {\n" +
+                "          \"exists\": {\n" +
+                "            \"field\": \"@timestamp\"\n" +
+                "          }\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"exists\": {\n" +
+                "            \"field\": \"host\"\n" +
+                "          }\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        HttpResponse res;
+        Assert.assertEquals(HttpStatus.SC_OK,
+                (res = rh.executePostRequest("/data/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode());
+        System.out.println(res.getBody());
+        Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
+        Assert.assertTrue(res.getBody().contains("a-normal-0"));
+        Assert.assertTrue(res.getBody().contains("response"));
+        Assert.assertTrue(res.getBody().contains("404"));
+
+        //only see's - timestamp and host field
+        //therefore non-existing does not exist so we expect c-missing2-0 to be returned
+        Assert.assertEquals(HttpStatus.SC_OK,
+                (res = rh.executePostRequest("/data/_search?pretty", query, encodeBasicHeader("fls_exists", "password"))).getStatusCode());
+        System.out.println(res.getBody());
+        Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
+        Assert.assertTrue(res.getBody().contains("a-normal-0"));
+        Assert.assertTrue(res.getBody().contains("c-missing2-0"));
+        Assert.assertFalse(res.getBody().contains("response"));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
@@ -218,6 +218,12 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
 	}
 
+	protected void assertHealthy() throws Exception {
+		Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_opendistro/_security/health?pretty").getStatusCode());
+		Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("admin", "admin")).getStatusCode());
+		Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("admin", "admin")).getStatusCode());
+	}
+
 	protected Settings defaultNodeSettings(boolean enableRestSSL) {
 		Settings.Builder builder = Settings.builder();
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiTest.java
@@ -99,7 +99,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         rh.keystore = "restapi/kirk-keystore.jks";
         rh.sendHTTPClientCertificate = true;
-        HttpResponse response = rh.executePutRequest("_searchguard/api/roles/dup", "{ \"invalid\"::{{ [\"*\"], \"cluster_permissions\": [\"*\"] }");
+        HttpResponse response = rh.executePutRequest("_opendistro/_security/api/roles/dup", "{ \"invalid\"::{{ [\"*\"], \"cluster_permissions\": [\"*\"] }");
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertTrue(response.getBody().contains("JsonParseException"));
         assertHealthy();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiTest.java
@@ -61,9 +61,48 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         rh.keystore = "restapi/kirk-keystore.jks";
         rh.sendHTTPClientCertificate = true;
-        HttpResponse response = rh.executeGetRequest("/_opendistro/_security/api/roles");
+        HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/roles");
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         Assert.assertFalse(response.getBody().contains("_meta"));
+    }
+
+    @Test
+    public void testPutDuplicateKeys() throws Exception {
+
+        setup();
+
+        rh.keystore = "restapi/kirk-keystore.jks";
+        rh.sendHTTPClientCertificate = true;
+        HttpResponse response = rh.executePutRequest("_opendistro/_security/api/roles/dup", "{ \"cluster_permissions\": [\"*\"], \"cluster_permissions\": [\"*\"] }");
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("JsonParseException"));
+        assertHealthy();
+    }
+
+    @Test
+    public void testPutUnknownKey() throws Exception {
+
+        setup();
+
+        rh.keystore = "restapi/kirk-keystore.jks";
+        rh.sendHTTPClientCertificate = true;
+        HttpResponse response = rh.executePutRequest("_opendistro/_security/api/roles/dup", "{ \"unknownkey\": [\"*\"], \"cluster_permissions\": [\"*\"] }");
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("invalid_keys"));
+        assertHealthy();
+    }
+
+    @Test
+    public void testPutInvalidJson() throws Exception {
+
+        setup();
+
+        rh.keystore = "restapi/kirk-keystore.jks";
+        rh.sendHTTPClientCertificate = true;
+        HttpResponse response = rh.executePutRequest("_searchguard/api/roles/dup", "{ \"invalid\"::{{ [\"*\"], \"cluster_permissions\": [\"*\"] }");
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("JsonParseException"));
+        assertHealthy();
     }
 
     @Test
@@ -90,17 +129,14 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         response = rh.executeGetRequest("/_opendistro/_security/api/roles/nothinghthere", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
-        // GET, new URL endpoint in SG6
         response = rh.executeGetRequest("/_opendistro/_security/api/roles/", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
-        // GET, new URL endpoint in SG6
         response = rh.executeGetRequest("/_opendistro/_security/api/roles", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         Assert.assertTrue(response.getBody().contains("\"cluster_permissions\":[\"*\"]"));
         Assert.assertFalse(response.getBody().contains("\"cluster_permissions\" : ["));
 
-        // GET, new URL endpoint in SG6, pretty
         response = rh.executeGetRequest("/_opendistro/_security/api/roles?pretty", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         Assert.assertFalse(response.getBody().contains("\"cluster_permissions\":[\"*\"]"));
@@ -147,7 +183,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         // user has only role starfleet left, role has READ access only
         checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "ships", 1);
 
-        // ES7 only supports one doc type, but SG permission checks run first
+        // ES7 only supports one doc type, but Opendistro permission checks run first
         // So we also get a 403 FORBIDDEN when tring to add new document type
         checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "public", 0);
 
@@ -208,7 +244,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "ships", 0);
 
         // now picard is only in opendistro_security_role_starfleet, which has write access to
-        // all indices. We collapse all document types in SG7 so this permission in the
+        // all indices. We collapse all document types in ODFE7 so this permission in the
         // starfleet role grants all permissions:
         //   public:  
         //       - 'indices:*'		

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
@@ -49,7 +49,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
 		Assert.assertEquals(35, settings.size());
 
-		response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/newuser\", \"value\": {\"password\": \"newuser\", \"opendistro_security_roles\": [\"opendistro_security_all_access\"] } }]", new Header[0]);
+		response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/newuser\", \"value\": {\"password\": \"newuser\", \"opendistro_security_roles\": [\"all_access\"] } }]", new Header[0]);
 		Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
 
 		response = rh.executeGetRequest("/_opendistro/_security/api/internalusers/newuser", new Header[0]);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
@@ -35,6 +35,31 @@ import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelpe
 public class UserApiTest extends AbstractRestApiUnitTest {
 
 	@Test
+	public void testOpenDistroSecurityRoles() throws Exception {
+
+		setup();
+
+		rh.keystore = "restapi/kirk-keystore.jks";
+		rh.sendHTTPClientCertificate = true;
+
+		// initial configuration, 5 users
+		HttpResponse response = rh
+				.executeGetRequest("_opendistro/_security/api/" + CType.INTERNALUSERS.toLCString());
+		Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
+		Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
+		Assert.assertEquals(35, settings.size());
+
+		response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/newuser\", \"value\": {\"password\": \"newuser\", \"opendistro_security_roles\": [\"opendistro_security_all_access\"] } }]", new Header[0]);
+		Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
+
+		response = rh.executeGetRequest("/_opendistro/_security/api/internalusers/newuser", new Header[0]);
+		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+		Assert.assertTrue(response.getBody().contains("\"opendistro_security_roles\":[\"all_access\"]"));
+
+		checkGeneralAccess(HttpStatus.SC_OK, "newuser", "newuser");
+	}
+
+	@Test
 	public void testUserApi() throws Exception {
 
 		setup();
@@ -47,7 +72,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 				.executeGetRequest("_opendistro/_security/api/" + CType.INTERNALUSERS.toLCString());
 		Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
 		Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertEquals(30, settings.size());
+		Assert.assertEquals(35, settings.size());
 		// --- GET
 
 		// GET, user admin, exists
@@ -55,7 +80,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
 		System.out.println(response.getBody());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertEquals(6, settings.size());
+		Assert.assertEquals(7, settings.size());
 		// hash must be filtered
 		Assert.assertEquals("", settings.get("admin.hash"));
 
@@ -345,7 +370,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		System.out.println(response.getBody());
 		Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertEquals(30, settings.size());
+		Assert.assertEquals(35, settings.size());
 
 		addUserWithPassword("tooshoort", "123", HttpStatus.SC_BAD_REQUEST);
 		addUserWithPassword("tooshoort", "1234567", HttpStatus.SC_BAD_REQUEST);
@@ -408,7 +433,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 				.executeGetRequest("_opendistro/_security/api/" + CType.INTERNALUSERS.toLCString());
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertEquals(30, settings.size());
+		Assert.assertEquals(35, settings.size());
 
 		addUserWithPassword(".my.dotuser0", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m",
 				HttpStatus.SC_CREATED);

--- a/src/test/resources/dlsfls/internal_users.yml
+++ b/src/test/resources/dlsfls/internal_users.yml
@@ -168,3 +168,6 @@ user_masked_custom:
 date_math:
   #password
   hash: $2a$12$YCBrpxYyFusK609FurY5Ee3BlmuzWw0qHwpwqEyNhM2.XnQY3Bxpe
+fls_exists:
+  #password
+  hash: $2a$12$YCBrpxYyFusK609FurY5Ee3BlmuzWw0qHwpwqEyNhM2.XnQY3Bxpe

--- a/src/test/resources/dlsfls/roles.yml
+++ b/src/test/resources/dlsfls/roles.yml
@@ -2,6 +2,18 @@
 _meta:
   type: "roles"
   config_version: 2
+opendistro_security_fls_exists:
+  cluster_permissions:
+    - "*"
+  index_permissions:
+    - index_patterns:
+        - "data"
+      allowed_actions:
+        - "*"
+      fls:
+        - "@timestamp"
+        - "host"
+        #- "non-existing"
 opendistro_security_date_math:
   index_permissions:
     - index_patterns:

--- a/src/test/resources/dlsfls/roles_mapping.yml
+++ b/src/test/resources/dlsfls/roles_mapping.yml
@@ -231,3 +231,6 @@ opendistro_security_combined:
 opendistro_security_date_math:
   users:
     - date_math
+opendistro_security_fls_exists:
+  users:
+    - fls_exists


### PR DESCRIPTION

1. Support for **Elasticsearch 7.3.2** 
2. Fixed leaked ldap connection 
3. Use combine bitset for DLS
4. Fixed FLS exists query on fields without norms and doc values 
5. Fixed field masking with aggregations
6. Introduced MaskedTermsEnum to fix field anonymization with aggregations
7. Added _seq_no and _primary_term to meta fields for FLS     
8. Fixed rest API validator to accept opendistro_secuirty_roles for internal users
9. Exception handling for SAML IdP at startup
10. Updated Jackson databind dependency to 2.9.9
11. Updated Kafka client dependency to 2.0.1 
12. Fixed access control exception for ldap2
13. Upgraded CXF to 2.3.9
14. Bumped jackson-databind from 2.9.9.2 to 2.9.10.1
15. Other minor fixes for detailed error logging 