### PR TITLE
Fix for modifying user backend-roles without giving password

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/InternalUsersValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/InternalUsersValidator.java
@@ -60,14 +60,8 @@ public class InternalUsersValidator extends AbstractConfigurationValidator {
                 if(contentAsMap != null && contentAsMap.containsKey("password")) {
                     final String password = (String) contentAsMap.get("password");
 
-                    if(password == null || password.isEmpty()) {
-                        if(log.isDebugEnabled()) {
-                            log.debug("Unable to validate password because no password is given");
-                        }
-                        return false;
-                    }
-
-                    if(!regex.isEmpty() && !Pattern.compile("^"+regex+"$").matcher(password).matches()) {
+                    // Password can be null/empty for an existing user. Regex will validate password if present
+                    if (password != null && !password.isEmpty() && !regex.isEmpty() && !Pattern.compile("^"+regex+"$").matcher(password).matches()) {
                         if(log.isDebugEnabled()) {
                             log.debug("Regex does not match password");
                         }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
@@ -347,6 +347,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
 		Assert.assertEquals(30, settings.size());
 
+		addUserWithPassword("tooshoort", "", HttpStatus.SC_BAD_REQUEST);
 		addUserWithPassword("tooshoort", "123", HttpStatus.SC_BAD_REQUEST);
 		addUserWithPassword("tooshoort", "1234567", HttpStatus.SC_BAD_REQUEST);
 		addUserWithPassword("tooshoort", "1Aa%", HttpStatus.SC_BAD_REQUEST);
@@ -393,6 +394,16 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 		Assert.assertTrue(response.getBody().contains("error"));
 		Assert.assertTrue(response.getBody().contains("xxx"));
+
+		response = rh.executePutRequest("/_opendistro/_security/api/internalusers/ok1", "{\"backend_roles\":[\"my-backend-role\"],\"attributes\":{},\"password\":\"\"}", new Header[0]);
+		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+		response = rh.executePutRequest("/_opendistro/_security/api/internalusers/ok1", "{\"backend_roles\":[\"my-backend-role\"],\"attributes\":{}}", new Header[0]);
+		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+		response = rh.executePutRequest("/_opendistro/_security/api/internalusers/ok1", "{\"backend_roles\":[\"my-backend-role\"],\"attributes\":{},\"password\":\"bla\"}",
+			new Header[0]);
+		Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 	}
 	
 	@Test


### PR DESCRIPTION
```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 27.023 s - in com.amazon.opendistroforelasticsearch.security.httpclient.HttpClientTest
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   MigrationTests.testSecurityMigrate:38 » NullPointer
[ERROR]   MigrationTests.testSecurityMigrateInvalid:66 » NullPointer
[ERROR]   MigrationTests.testSecurityValidate:96 » NullPointer
[ERROR]   MigrationTests.testSgValidateWithInvalidConfig:116 » NullPointer
[INFO] 
[ERROR] Tests run: 560, Failures: 0, Errors: 4, Skipped: 5
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  46:59 min
[INFO] Finished at: 2019-12-05T20:05:18Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project opendistro_security_advanced_modules: There are test failures.
[ERROR] 
[ERROR] Please refer to /security-advanced-modules/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```

Note: Test errors are from a previous commit.

Description:
This issue is to fix a bug where an existing user was unable to specify backend roles (or other fields) while modifying kibana internal users. 

Tests:
Added unit tests. 

Tested manually with ES7.1.1
* Password must be present and valid for new user
```
curl -k -XPUT -H 'Content-Type: application/json' -u admin:admin https://localhost:9200/_opendistro/_security/api/internalusers/newUser123 -d '{"backend_roles":["my-backend-role"],"attributes":{}}'
{"status":"BAD_REQUEST","message":"Please specify either 'hash' or 'password' when creating a new internal user."}________________________________________________________________________________

curl -k -XPUT -H 'Content-Type: application/json' -u admin:admin https://localhost:9200/_opendistro/_security/api/internalusers/newUser123 -d '{"backend_roles":["my-backend-role"],"attributes":{}, "password":""}'
{"status":"BAD_REQUEST","message":"Please specify either 'hash' or 'password' when creating a new internal user."}________________________________________________________________________________

curl -k -XPUT -H 'Content-Type: application/json' -u admin:admin https://localhost:9200/_opendistro/_security/api/internalusers/newUser123 -d '{"backend_roles":["my-backend-role"],"attributes":{}, "password":"new123!TEST"}'
{"status":"CREATED","message":"'newUser123' created."}________________________________________________________________________________
```

* Password need not be present for existing user. If present must be valid.
```
curl -k -XPUT -H 'Content-Type: application/json' -u admin:admin https://localhost:9200/_opendistro/_security/api/internalusers/newUser123 -d '{"backend_roles":["my-backend-role"],"attributes":{}}'
{"status":"OK","message":"'newUser123' updated."}________________________________________________________________________________

curl -k -XPUT -H 'Content-Type: application/json' -u admin:admin https://localhost:9200/_opendistro/_security/api/internalusers/newUser123 -d '{"backend_roles":["my-backend-role"],"attributes":{}, "password": "test123"}'
{"status":"error","reason":"Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one digit, and one special character."}____________________
```

