### PR TITLE
Fix Date formatter to use year instead of week year

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/dlsfls/DateMathTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/dlsfls/DateMathTest.java
@@ -36,7 +36,7 @@ public class DateMathTest extends AbstractDlsFlsTest{
 
     protected void populateData(TransportClient tc) {
 
-        SimpleDateFormat sdf = new SimpleDateFormat("YYYY.MM.dd", OpenDistroSecurityUtils.EN_Locale);
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy.MM.dd", OpenDistroSecurityUtils.EN_Locale);
         sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
 
         String date = sdf.format(new Date());


### PR DESCRIPTION
Fix based on: https://stackoverflow.com/questions/8686331/y-returns-2012-while-y-returns-2011-in-simpledateformat 

